### PR TITLE
Enhance browser UI and SEO: accessible form, page metadata, schema, and styles

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,9 @@ importers:
       '@astrojs/react':
         specifier: ^4.4.0
         version: 4.4.2(@types/node@25.3.3)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@astrojs/sitemap':
+        specifier: ^3.7.0
+        version: 3.7.0
       astro:
         specifier: ^5.14.0
         version: 5.18.0(@types/node@25.3.3)(rollup@4.59.0)(typescript@5.9.3)
@@ -75,6 +78,9 @@ packages:
       '@types/react-dom': ^17.0.17 || ^18.0.6 || ^19.0.0
       react: ^17.0.2 || ^18.0.0 || ^19.0.0
       react-dom: ^17.0.2 || ^18.0.0 || ^19.0.0
+
+  '@astrojs/sitemap@3.7.0':
+    resolution: {integrity: sha512-+qxjUrz6Jcgh+D5VE1gKUJTA3pSthuPHe6Ao5JCxok794Lewx8hBFaWHtOnN0ntb2lfOf7gvOi9TefUswQ/ZVA==}
 
   '@astrojs/telemetry@3.3.0':
     resolution: {integrity: sha512-UFBgfeldP06qu6khs/yY+q1cDAaArM2/7AEIqQ9Cuvf7B1hNLq0xDrZkct+QoIGyjq56y8IaE2I3CTvG99mlhQ==}
@@ -888,6 +894,9 @@ packages:
   '@types/nlcst@2.0.3':
     resolution: {integrity: sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA==}
 
+  '@types/node@17.0.45':
+    resolution: {integrity: sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==}
+
   '@types/node@25.3.3':
     resolution: {integrity: sha512-DpzbrH7wIcBaJibpKo9nnSQL0MTRdnWttGyE5haGwK86xgMOkFLp7vEyfQPGLOJh5wNYiJ3V9PmUMDhV9u8kkQ==}
 
@@ -898,6 +907,9 @@ packages:
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@types/sax@1.2.7':
+    resolution: {integrity: sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==}
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
@@ -963,6 +975,9 @@ packages:
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
+
+  arg@5.0.2:
+    resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -1734,6 +1749,11 @@ packages:
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
+  sitemap@8.0.3:
+    resolution: {integrity: sha512-9Ew1tR2WYw8RGE2XLy7GjkusvYXy8Rg6y8TYuBuQMfIEdGcWoJpY2Wr5DzsEiL/TKCw56+YKTCCUHglorEYK+A==}
+    engines: {node: '>=14.0.0', npm: '>=6.0.0'}
+    hasBin: true
+
   smol-toml@1.6.0:
     resolution: {integrity: sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw==}
     engines: {node: '>= 18'}
@@ -1750,6 +1770,9 @@ packages:
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  stream-replace-string@2.0.0:
+    resolution: {integrity: sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -2182,6 +2205,12 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  '@astrojs/sitemap@3.7.0':
+    dependencies:
+      sitemap: 8.0.3
+      stream-replace-string: 2.0.0
+      zod: 3.25.76
 
   '@astrojs/telemetry@3.3.0':
     dependencies:
@@ -2793,6 +2822,8 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
+  '@types/node@17.0.45': {}
+
   '@types/node@25.3.3':
     dependencies:
       undici-types: 7.18.2
@@ -2804,6 +2835,10 @@ snapshots:
   '@types/react@19.2.14':
     dependencies:
       csstype: 3.2.3
+
+  '@types/sax@1.2.7':
+    dependencies:
+      '@types/node': 25.3.3
 
   '@types/unist@3.0.3': {}
 
@@ -2876,6 +2911,8 @@ snapshots:
     dependencies:
       normalize-path: 3.0.0
       picomatch: 2.3.1
+
+  arg@5.0.2: {}
 
   argparse@2.0.1: {}
 
@@ -4041,6 +4078,13 @@ snapshots:
 
   sisteransi@1.0.5: {}
 
+  sitemap@8.0.3:
+    dependencies:
+      '@types/node': 17.0.45
+      '@types/sax': 1.2.7
+      arg: 5.0.2
+      sax: 1.5.0
+
   smol-toml@1.6.0: {}
 
   source-map-js@1.2.1: {}
@@ -4050,6 +4094,8 @@ snapshots:
   stackback@0.0.2: {}
 
   std-env@3.10.0: {}
+
+  stream-replace-string@2.0.0: {}
 
   string-width@4.2.3:
     dependencies:

--- a/src/browser/astro.config.mjs
+++ b/src/browser/astro.config.mjs
@@ -1,6 +1,8 @@
 import { defineConfig } from 'astro/config'
 import react from '@astrojs/react'
+import sitemap from '@astrojs/sitemap'
 
 export default defineConfig({
-  integrations: [react()],
+  site: 'https://ghmd.roman910.dev',
+  integrations: [react(), sitemap()],
 })

--- a/src/browser/package.json
+++ b/src/browser/package.json
@@ -15,6 +15,7 @@
   },
   "devDependencies": {
     "@astrojs/react": "^4.4.0",
-    "astro": "^5.14.0"
+    "astro": "^5.14.0",
+    "@astrojs/sitemap": "^3.7.0"
   }
 }

--- a/src/browser/public/robots.txt
+++ b/src/browser/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://ghmd.roman910.dev/sitemap-index.xml

--- a/src/browser/src/App.tsx
+++ b/src/browser/src/App.tsx
@@ -66,26 +66,31 @@ export function App() {
 	}
 
 	return (
-		<main>
-			<h1>ghmd browser</h1>
-			<p>Drop markdown in, download html out.</p>
+		<section className="tool" aria-labelledby="converter-title">
+			<h2 id="converter-title">Convert markdown</h2>
+			<p className="tagline">Drop markdown in, download HTML out.</p>
 
+			<label htmlFor="markdown-file">Upload markdown file</label>
 			<input
+				id="markdown-file"
 				type="file"
 				accept=".md,.markdown,text/markdown,text/plain"
 				onChange={onFileUpload}
 			/>
 
+			<label htmlFor="markdown-input">Markdown input</label>
 			<textarea
+				id="markdown-input"
 				value={markdown}
 				onChange={(event) => setMarkdown(event.target.value)}
 				placeholder="Write markdown here..."
 			/>
 
 			<div className="row">
-				<label>
+				<label htmlFor="theme-select">
 					Theme
 					<select
+						id="theme-select"
 						value={theme}
 						onChange={(event) => setTheme(event.target.value as GhmdTheme)}
 					>
@@ -96,9 +101,10 @@ export function App() {
 					<small>{`${optionDescriptionByName['--light']} / ${optionDescriptionByName['--dark']}`}</small>
 				</label>
 
-				<label>
+				<label htmlFor="mode-select">
 					Mode
 					<select
+						id="mode-select"
 						value={mode}
 						onChange={(event) => setMode(event.target.value as GhmdMode)}
 					>
@@ -126,6 +132,6 @@ export function App() {
 			</button>
 
 			{error && <p className="error">{error}</p>}
-		</main>
+		</section>
 	)
 }

--- a/src/browser/src/pages/index.astro
+++ b/src/browser/src/pages/index.astro
@@ -1,6 +1,32 @@
 ---
 import { App } from '../App'
 import '../styles.css'
+
+const pageTitle = 'Markdown to HTML Converter (Free Online) | ghmd browser'
+const pageDescription =
+	'Convert Markdown to HTML online with GitHub Flavored Markdown support. Free, fast, and open source.'
+const githubRepoUrl = 'https://github.com/roman910/ghmd'
+const appUrl = 'https://ghmd.roman910.dev'
+
+const webAppSchema = {
+	'@context': 'https://schema.org',
+	'@type': 'WebApplication',
+	name: 'ghmd browser',
+	applicationCategory: 'DeveloperApplication',
+	operatingSystem: 'Web',
+	url: appUrl,
+	description: pageDescription,
+	offers: {
+		'@type': 'Offer',
+		price: '0',
+		priceCurrency: 'USD',
+	},
+	sourceOrganization: {
+		'@type': 'Organization',
+		name: 'ghmd',
+		url: githubRepoUrl,
+	},
+}
 ---
 
 <!doctype html>
@@ -8,9 +34,52 @@ import '../styles.css'
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>ghmd browser</title>
+    <title>{pageTitle}</title>
+    <meta name="description" content={pageDescription} />
+    <link rel="canonical" href={appUrl} />
+    <meta property="og:title" content={pageTitle} />
+    <meta property="og:description" content={pageDescription} />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content={appUrl} />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content={pageTitle} />
+    <meta name="twitter:description" content={pageDescription} />
+    <script type="application/ld+json" set:html={JSON.stringify(webAppSchema)}></script>
   </head>
   <body>
-    <App client:load />
+    <main>
+      <header class="hero">
+        <h1>Markdown to HTML converter</h1>
+        <p>
+          ghmd browser converts Markdown files into ready-to-share HTML using GitHub Flavored Markdown,
+          with options for plain Markdown mode, light/dark themes, and embedded CSS.
+        </p>
+      </header>
+
+      <section aria-label="Markdown to HTML conversion tool">
+        <App client:load />
+      </section>
+
+      <section aria-labelledby="how-to-use">
+        <h2 id="how-to-use">How to use</h2>
+        <ol>
+          <li>Upload a <code>.md</code> file or type/paste Markdown in the editor.</li>
+          <li>Pick your output options (theme, markdown mode, and embedded CSS).</li>
+          <li>Click <strong>Convert and download HTML</strong> to save the generated file.</li>
+        </ol>
+      </section>
+
+      <section aria-labelledby="about-ghmd">
+        <h2 id="about-ghmd">About this tool</h2>
+        <p>
+          ghmd is an open-source project with Python and Node.js implementations. This browser tool uses
+          the same Node-based converter and runs fully in your browser for quick, no-signup conversions.
+        </p>
+        <p>
+          Project repository:
+          <a href={githubRepoUrl} rel="noopener noreferrer">{githubRepoUrl}</a>
+        </p>
+      </section>
+    </main>
   </body>
 </html>

--- a/src/browser/src/styles.css
+++ b/src/browser/src/styles.css
@@ -6,6 +6,7 @@
 		Segoe UI,
 		Roboto,
 		sans-serif;
+	color: #0f172a;
 }
 
 body {
@@ -19,7 +20,26 @@ main {
 	padding: 24px;
 	display: flex;
 	flex-direction: column;
+	gap: 20px;
+}
+
+.hero p {
+	margin-top: 8px;
+	line-height: 1.5;
+}
+
+.tool {
+	display: flex;
+	flex-direction: column;
 	gap: 12px;
+	background: #fff;
+	padding: 18px;
+	border-radius: 10px;
+	border: 1px solid #e2e8f0;
+}
+
+.tagline {
+	margin-top: -4px;
 }
 
 textarea {
@@ -54,4 +74,14 @@ button {
 
 .error {
 	color: #b91c1c;
+}
+
+section h2 {
+	margin-bottom: 8px;
+}
+
+ol {
+	margin-top: 0;
+	padding-left: 20px;
+	line-height: 1.5;
 }


### PR DESCRIPTION
### Motivation
- Improve the browser-based markdown-to-HTML tool's usability and accessibility by adding semantic structure, form labels, and ARIA relationships.
- Improve discoverability and sharing by adding page metadata, Open Graph/Twitter tags, canonical link, and structured data for the web app.
- Polish the visual layout and spacing so the tool is easier to scan and use.

### Description
- Update `App.tsx` to use semantic containers (`section`), add `aria-labelledby`, labelled inputs (`id` and `htmlFor`), and clearer headings and copy for the converter UI while preserving existing conversion logic and error handling.
- Update `pages/index.astro` to set a descriptive page title and description, add canonical and Open Graph/Twitter meta tags, inject JSON-LD `WebApplication` schema, and add hero, usage, and about sections around the app mount point.
- Revise `styles.css` to restyle the page layout and the tool card with spacing, colors, rounded borders, improved typography, and new rules for hero, tagline, and lists.

### Testing
- Ran a TypeScript type-check (`tsc --noEmit`) which completed without errors.
- Performed a project build (`npm run build`) which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a81d988854832b95708cc3da8b382c)