### PR TITLE
Add favicon and manifest tags to browser app head

### DIFF
--- a/src/browser/src/pages/index.astro
+++ b/src/browser/src/pages/index.astro
@@ -44,6 +44,12 @@ const webAppSchema = {
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content={pageTitle} />
     <meta name="twitter:description" content={pageDescription} />
+    <link rel="icon" type="image/png" href="/favicon-96x96.png" sizes="96x96" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="shortcut icon" href="/favicon.ico" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+    <meta name="apple-mobile-web-app-title" content="ghmd" />
+    <link rel="manifest" href="/site.webmanifest" />
     <script type="application/ld+json" set:html={JSON.stringify(webAppSchema)}></script>
   </head>
   <body>


### PR DESCRIPTION
### Motivation
- Reference newly added icon assets and PWA manifest from the app HTML head so browsers and devices can show the correct favicon and discover the site manifest.

### Description
- Inserted favicon links for PNG (`/favicon-96x96.png`), SVG (`/favicon.svg`), and ICO (`/favicon.ico`), added an Apple touch icon and `apple-mobile-web-app-title` meta, and linked the site manifest (`/site.webmanifest`) in `src/browser/src/pages/index.astro`.

### Testing
- Ran `pnpm -C src/browser run build`, which failed in this environment because the `astro` binary is not available on PATH.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a97ba088cc832b85eb9574a693eb38)