### PR TITLE
Improve converter option hierarchy styling

### DIFF
--- a/src/browser/src/App.tsx
+++ b/src/browser/src/App.tsx
@@ -87,8 +87,8 @@ export function App() {
 			/>
 
 			<div className="row">
-				<label htmlFor="theme-select">
-					Theme
+				<label htmlFor="theme-select" className="option-field">
+					<span className="option-label">Theme</span>
 					<select
 						id="theme-select"
 						value={theme}
@@ -98,11 +98,11 @@ export function App() {
 						<option value="light">Light</option>
 						<option value="dark">Dark</option>
 					</select>
-					<small>{`${optionDescriptionByName['--light']} / ${optionDescriptionByName['--dark']}`}</small>
+					<small className="field-help">{`${optionDescriptionByName['--light']} / ${optionDescriptionByName['--dark']}`}</small>
 				</label>
 
-				<label htmlFor="mode-select">
-					Mode
+				<label htmlFor="mode-select" className="option-field">
+					<span className="option-label">Mode</span>
 					<select
 						id="mode-select"
 						value={mode}
@@ -111,18 +111,18 @@ export function App() {
 						<option value="gfm">GitHub Flavored Markdown</option>
 						<option value="markdown">Plain markdown (--no-gfm)</option>
 					</select>
-					<small>{optionDescriptionByName['--no-gfm']}</small>
+					<small className="field-help">{optionDescriptionByName['--no-gfm']}</small>
 				</label>
 
-				<label className="inline">
+				<label className="option-field inline">
 					<input
 						type="checkbox"
 						checked={embedCss}
 						onChange={(event) => setEmbedCss(event.target.checked)}
 					/>
 					<span>
-						Embed CSS
-						<small>{optionDescriptionByName['--embed-css']}</small>
+						<span className="option-label">Embed CSS</span>
+						<small className="field-help">{optionDescriptionByName['--embed-css']}</small>
 					</span>
 				</label>
 			</div>

--- a/src/browser/src/styles.css
+++ b/src/browser/src/styles.css
@@ -53,6 +53,7 @@ textarea {
 	display: flex;
 	gap: 16px;
 	flex-wrap: wrap;
+	align-items: flex-start;
 }
 
 label {
@@ -61,10 +62,39 @@ label {
 	gap: 6px;
 }
 
+.option-field {
+	flex: 1 1 230px;
+	padding: 10px 12px;
+	border: 1px solid #e2e8f0;
+	border-radius: 8px;
+	background: #f8fafc;
+}
+
+.option-label {
+	font-weight: 600;
+	color: #0f172a;
+}
+
+.field-help {
+	margin-top: 2px;
+	line-height: 1.4;
+	color: #475569;
+}
+
 .inline {
 	flex-direction: row;
-	align-items: center;
-	margin-top: 24px;
+	align-items: flex-start;
+	gap: 10px;
+}
+
+.inline input {
+	margin-top: 3px;
+}
+
+.inline > span {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
 }
 
 button {


### PR DESCRIPTION
### Motivation

- Improve the visual hierarchy and consistency of the converter controls so the Theme, Mode, and Embed CSS options read as related option blocks without performing a full restyle.

### Description

- Update the converter markup to wrap each option in a light option container and expose a consistent label + helper-text structure for `Theme`, `Mode`, and `Embed CSS` in `src/browser/src/App.tsx`.
- Replace inline text headings with `<span className="option-label">` and move helper text into `<small className="field-help">` to separate semantics from control elements.
- Add compact, subtle styling for the new option groups and tweak layout alignment: add `.option-field`, `.option-label`, `.field-help`, adjust `.row` alignment and `.inline` checkbox layout in `src/browser/src/styles.css`.
- Changes are limited to the browser UI; no behavior changes to conversion logic were made.

### Testing

- Ran `pnpm --filter ghmd-browser build`, which failed in this environment due to inability to resolve the `ghmd-js` package entry during the Astro/Vite build (build failed). 
- Ran `pnpm build:node`, which failed because the generated `./generated/shared.js` module is not present in the environment (build failed).
- Started the browser dev server with `pnpm --dir ./src/browser dev`, which launched and allowed a visual verification; a screenshot artifact was captured at `artifacts/converter-hierarchy.png` for review (dev server started successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aab084e10c832ba918dbdce9269819)