### PR TITLE
Add PostHog tracking to Astro browser app

### DIFF
--- a/src/browser/src/components/posthog.astro
+++ b/src/browser/src/components/posthog.astro
@@ -1,0 +1,10 @@
+---
+// src/components/posthog.astro
+---
+<script is:inline>
+	!function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init capture register register_once register_for_session unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group identify setPersonProperties setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags resetGroups onFeatureFlags addFeatureFlagsHandler onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey getNextSurveyStep".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+	posthog.init('phc_tSWcZA6Jjtg6WE7Wp8shd5XQpentWC963XfQi4UeNT2', {
+		api_host: 'https://eu.i.posthog.com',
+		defaults: '2026-01-30',
+	})
+</script>

--- a/src/browser/src/components/posthog.astro
+++ b/src/browser/src/components/posthog.astro
@@ -4,7 +4,9 @@
 <script is:inline>
 	!function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init capture register register_once register_for_session unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group identify setPersonProperties setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags resetGroups onFeatureFlags addFeatureFlagsHandler onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey getNextSurveyStep".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
 	posthog.init('phc_tSWcZA6Jjtg6WE7Wp8shd5XQpentWC963XfQi4UeNT2', {
-		api_host: 'https://eu.i.posthog.com',
+		api_host: 'https://ghmd-phrp.roman910.dev',
+		ui_host: 'https://eu.posthog.com',
 		defaults: '2026-01-30',
+		person_profiles: 'identified_only',
 	})
 </script>

--- a/src/browser/src/layouts/PostHogLayout.astro
+++ b/src/browser/src/layouts/PostHogLayout.astro
@@ -1,0 +1,43 @@
+---
+import PostHog from '../components/posthog.astro'
+
+interface Props {
+	pageTitle: string
+	pageDescription: string
+	appUrl: string
+	webAppSchema: Record<string, unknown>
+}
+
+const { pageTitle, pageDescription, appUrl, webAppSchema } = Astro.props
+---
+
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>{pageTitle}</title>
+		<meta name="description" content={pageDescription} />
+		<link rel="canonical" href={appUrl} />
+		<meta property="og:title" content={pageTitle} />
+		<meta property="og:description" content={pageDescription} />
+		<meta property="og:type" content="website" />
+		<meta property="og:url" content={appUrl} />
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content={pageTitle} />
+		<meta name="twitter:description" content={pageDescription} />
+		<link rel="icon" type="image/png" href="/favicon-96x96.png" sizes="96x96" />
+		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+		<link rel="shortcut icon" href="/favicon.ico" />
+		<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+		<meta name="apple-mobile-web-app-title" content="ghmd" />
+		<link rel="manifest" href="/site.webmanifest" />
+		<script type="application/ld+json" set:html={JSON.stringify(webAppSchema)}></script>
+		<PostHog />
+	</head>
+	<body>
+		<main>
+			<slot />
+		</main>
+	</body>
+</html>

--- a/src/browser/src/pages/index.astro
+++ b/src/browser/src/pages/index.astro
@@ -1,5 +1,6 @@
 ---
 import { App } from '../App'
+import PostHogLayout from '../layouts/PostHogLayout.astro'
 import '../styles.css'
 
 const pageTitle = 'Markdown to HTML Converter (Free Online) | ghmd browser'
@@ -29,63 +30,42 @@ const webAppSchema = {
 }
 ---
 
-<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>{pageTitle}</title>
-    <meta name="description" content={pageDescription} />
-    <link rel="canonical" href={appUrl} />
-    <meta property="og:title" content={pageTitle} />
-    <meta property="og:description" content={pageDescription} />
-    <meta property="og:type" content="website" />
-    <meta property="og:url" content={appUrl} />
-    <meta name="twitter:card" content="summary" />
-    <meta name="twitter:title" content={pageTitle} />
-    <meta name="twitter:description" content={pageDescription} />
-    <link rel="icon" type="image/png" href="/favicon-96x96.png" sizes="96x96" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <link rel="shortcut icon" href="/favicon.ico" />
-    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
-    <meta name="apple-mobile-web-app-title" content="ghmd" />
-    <link rel="manifest" href="/site.webmanifest" />
-    <script type="application/ld+json" set:html={JSON.stringify(webAppSchema)}></script>
-  </head>
-  <body>
-    <main>
-      <header class="hero">
-        <h1>Markdown to HTML converter</h1>
-        <p>
-          ghmd browser converts Markdown files into ready-to-share HTML using GitHub Flavored Markdown,
-          with options for plain Markdown mode, light/dark themes, and embedded CSS.
-        </p>
-      </header>
+<PostHogLayout
+	pageTitle={pageTitle}
+	pageDescription={pageDescription}
+	appUrl={appUrl}
+	webAppSchema={webAppSchema}
+>
+	<header class="hero">
+		<h1>Markdown to HTML converter</h1>
+		<p>
+			ghmd browser converts Markdown files into ready-to-share HTML using GitHub Flavored Markdown,
+			with options for plain Markdown mode, light/dark themes, and embedded CSS.
+		</p>
+	</header>
 
-      <section aria-label="Markdown to HTML conversion tool">
-        <App client:load />
-      </section>
+	<section aria-label="Markdown to HTML conversion tool">
+		<App client:load />
+	</section>
 
-      <section aria-labelledby="how-to-use">
-        <h2 id="how-to-use">How to use</h2>
-        <ol>
-          <li>Upload a <code>.md</code> file or type/paste Markdown in the editor.</li>
-          <li>Pick your output options (theme, markdown mode, and embedded CSS).</li>
-          <li>Click <strong>Convert and download HTML</strong> to save the generated file.</li>
-        </ol>
-      </section>
+	<section aria-labelledby="how-to-use">
+		<h2 id="how-to-use">How to use</h2>
+		<ol>
+			<li>Upload a <code>.md</code> file or type/paste Markdown in the editor.</li>
+			<li>Pick your output options (theme, markdown mode, and embedded CSS).</li>
+			<li>Click <strong>Convert and download HTML</strong> to save the generated file.</li>
+		</ol>
+	</section>
 
-      <section aria-labelledby="about-ghmd">
-        <h2 id="about-ghmd">About this tool</h2>
-        <p>
-          ghmd is an open-source project with Python and Node.js implementations. This browser tool uses
-          the same Node-based converter and runs fully in your browser for quick, no-signup conversions.
-        </p>
-        <p>
-          Project repository:
-          <a href={githubRepoUrl} rel="noopener noreferrer">{githubRepoUrl}</a>
-        </p>
-      </section>
-    </main>
-  </body>
-</html>
+	<section aria-labelledby="about-ghmd">
+		<h2 id="about-ghmd">About this tool</h2>
+		<p>
+			ghmd is an open-source project with Python and Node.js implementations. This browser tool uses
+			the same Node-based converter and runs fully in your browser for quick, no-signup conversions.
+		</p>
+		<p>
+			Project repository:
+			<a href={githubRepoUrl} rel="noopener noreferrer">{githubRepoUrl}</a>
+		</p>
+	</section>
+</PostHogLayout>


### PR DESCRIPTION
### Motivation
- Add frontend analytics to the Astro-based browser app so pageviews and interactions are tracked via PostHog.
- Centralize page `<head>` metadata and tracking injection to make it easy to reuse across pages.

### Description
- Add `src/browser/src/components/posthog.astro` containing the official inline PostHog web snippet with the project token and configuration so tracking initializes on page load.
- Add `src/browser/src/layouts/PostHogLayout.astro` which exposes props for page metadata/schema and injects `<PostHog />` into the `<head>` while rendering a `<slot />` for page content.
- Update `src/browser/src/pages/index.astro` to use `PostHogLayout` and pass the existing `pageTitle`, `pageDescription`, `appUrl`, and `webAppSchema` props while preserving the page content and the `App` mount.

### Testing
- Ran `pnpm --dir src/browser build`, which failed due to an unresolved `ghmd-js` package entry during the bundling step in this workspace state.
- Ran `pnpm --dir src/browser exec tsc --noEmit`, which failed due to missing `vite/client` type definitions in this workspace state.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aaff67fe98832bb5beb612f6e0add9)