### PR TITLE
fix(browser): update GitHub repository URL on homepage

### DIFF
--- a/src/browser/src/pages/index.astro
+++ b/src/browser/src/pages/index.astro
@@ -6,7 +6,7 @@ import '../styles.css'
 const pageTitle = 'Markdown to HTML Converter (Free Online) | ghmd browser'
 const pageDescription =
 	'Convert Markdown to HTML online with GitHub Flavored Markdown support. Free, fast, and open source.'
-const githubRepoUrl = 'https://github.com/roman910/ghmd'
+const githubRepoUrl = 'https://github.com/roman910dev/ghmd'
 const appUrl = 'https://ghmd.roman910.dev'
 
 const webAppSchema = {


### PR DESCRIPTION
### Motivation
- Correct the homepage GitHub repository URL so the page and its structured data point to the actual repository owner (`roman910dev`).

### Description
- Replace `https://github.com/roman910/ghmd` with `https://github.com/roman910dev/ghmd` in `src/browser/src/pages/index.astro`.

### Testing
- Verified the change with `rg -n "github.com/roman910/ghmd|githubRepoUrl" src/browser/src/pages/index.astro` which shows the updated URL, and attempted `pnpm build:browser` and `pnpm build:node` which failed due to unrelated existing build issues (`ghmd-js` resolution and a missing generated file) not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6aed52e6c832bbf036567e72496e0)