### PR TITLE
Add PostHog capture for browser HTML conversion clicks

### DIFF
--- a/src/browser/src/App.tsx
+++ b/src/browser/src/App.tsx
@@ -46,7 +46,7 @@ export function App() {
 		const [file] = event.target.files ?? []
 		if (!file) return
 
-		window.posthog?.capture('browser_markdown_file_uploaded', {
+		capturePostHogEvent('browser_markdown_file_uploaded', {
 			fileExtension: file.name.split('.').pop()?.toLowerCase(),
 			fileSizeBytes: file.size,
 			fileType: file.type || 'unknown',

--- a/src/browser/src/App.tsx
+++ b/src/browser/src/App.tsx
@@ -4,6 +4,16 @@ import type { ChangeEvent } from 'react'
 import { useState } from 'react'
 import { strings } from './generated/shared'
 
+type PostHogCaptureProperties = Record<string, boolean | number | string | null | undefined>
+
+declare global {
+	interface Window {
+		posthog?: {
+			capture: (eventName: string, properties?: PostHogCaptureProperties) => void
+		}
+	}
+}
+
 const optionDescriptionByName = Object.fromEntries(
 	strings.help.options.map(({ name, description }) => [name, description]),
 )
@@ -15,6 +25,13 @@ const readText = (file: Blob): Promise<string> =>
 		reader.onerror = () => reject(new Error('Could not read file.'))
 		reader.readAsText(file)
 	})
+
+const capturePostHogEvent = (
+	eventName: string,
+	properties?: PostHogCaptureProperties,
+) => {
+	window.posthog?.capture(eventName, properties)
+}
 
 export function App() {
 	const [markdown, setMarkdown] = useState('# Hello from ghmd browser\n')
@@ -38,7 +55,42 @@ export function App() {
 		}
 	}
 
+	function onThemeChange(event: ChangeEvent<HTMLSelectElement>) {
+		const nextTheme = event.target.value as GhmdTheme
+		setTheme(nextTheme)
+		capturePostHogEvent('browser_option_changed', {
+			optionName: 'theme',
+			optionValue: nextTheme,
+		})
+	}
+
+	function onModeChange(event: ChangeEvent<HTMLSelectElement>) {
+		const nextMode = event.target.value as GhmdMode
+		setMode(nextMode)
+		capturePostHogEvent('browser_option_changed', {
+			optionName: 'mode',
+			optionValue: nextMode,
+		})
+	}
+
+	function onEmbedCssChange(event: ChangeEvent<HTMLInputElement>) {
+		const nextEmbedCss = event.target.checked
+		setEmbedCss(nextEmbedCss)
+		capturePostHogEvent('browser_option_changed', {
+			optionName: 'embed_css',
+			optionValue: nextEmbedCss,
+		})
+	}
+
 	async function onConvert() {
+		capturePostHogEvent('browser_convert_to_html_clicked', {
+			embedCss,
+			mode,
+			theme,
+			hasMarkdownContent: markdown.trim().length > 0,
+			hasUploadedFile: filename !== 'document.md',
+		})
+
 		try {
 			setBusy(true)
 			setError('')
@@ -92,7 +144,7 @@ export function App() {
 					<select
 						id="theme-select"
 						value={theme}
-						onChange={(event) => setTheme(event.target.value as GhmdTheme)}
+						onChange={onThemeChange}
 					>
 						<option value="system">System</option>
 						<option value="light">Light</option>
@@ -106,7 +158,7 @@ export function App() {
 					<select
 						id="mode-select"
 						value={mode}
-						onChange={(event) => setMode(event.target.value as GhmdMode)}
+						onChange={onModeChange}
 					>
 						<option value="gfm">GitHub Flavored Markdown</option>
 						<option value="markdown">Plain markdown (--no-gfm)</option>
@@ -118,7 +170,7 @@ export function App() {
 					<input
 						type="checkbox"
 						checked={embedCss}
-						onChange={(event) => setEmbedCss(event.target.checked)}
+						onChange={onEmbedCssChange}
 					/>
 					<span>
 						<span className="option-label">Embed CSS</span>

--- a/src/browser/src/App.tsx
+++ b/src/browser/src/App.tsx
@@ -4,6 +4,16 @@ import type { ChangeEvent } from 'react'
 import { useState } from 'react'
 import { strings } from './generated/shared'
 
+type PostHogCaptureProperties = Record<string, boolean | number | string | null | undefined>
+
+declare global {
+	interface Window {
+		posthog?: {
+			capture: (eventName: string, properties?: PostHogCaptureProperties) => void
+		}
+	}
+}
+
 const optionDescriptionByName = Object.fromEntries(
 	strings.help.options.map(({ name, description }) => [name, description]),
 )
@@ -39,6 +49,14 @@ export function App() {
 	}
 
 	async function onConvert() {
+		window.posthog?.capture('browser_convert_to_html_clicked', {
+			embedCss,
+			mode,
+			theme,
+			hasMarkdownContent: markdown.trim().length > 0,
+			hasUploadedFile: filename !== 'document.md',
+		})
+
 		try {
 			setBusy(true)
 			setError('')

--- a/src/browser/src/App.tsx
+++ b/src/browser/src/App.tsx
@@ -39,6 +39,12 @@ export function App() {
 		const [file] = event.target.files ?? []
 		if (!file) return
 
+		window.posthog?.capture('browser_markdown_file_uploaded', {
+			fileExtension: file.name.split('.').pop()?.toLowerCase(),
+			fileSizeBytes: file.size,
+			fileType: file.type || 'unknown',
+		})
+
 		try {
 			setError('')
 			setFilename(file.name)

--- a/src/browser/src/App.tsx
+++ b/src/browser/src/App.tsx
@@ -4,6 +4,16 @@ import type { ChangeEvent } from 'react'
 import { useState } from 'react'
 import { strings } from './generated/shared'
 
+type PostHogCaptureProperties = Record<string, boolean | number | string | null | undefined>
+
+declare global {
+	interface Window {
+		posthog?: {
+			capture: (eventName: string, properties?: PostHogCaptureProperties) => void
+		}
+	}
+}
+
 const optionDescriptionByName = Object.fromEntries(
 	strings.help.options.map(({ name, description }) => [name, description]),
 )
@@ -15,6 +25,13 @@ const readText = (file: Blob): Promise<string> =>
 		reader.onerror = () => reject(new Error('Could not read file.'))
 		reader.readAsText(file)
 	})
+
+const capturePostHogEvent = (
+	eventName: string,
+	properties?: PostHogCaptureProperties,
+) => {
+	window.posthog?.capture(eventName, properties)
+}
 
 export function App() {
 	const [markdown, setMarkdown] = useState('# Hello from ghmd browser\n')
@@ -38,7 +55,42 @@ export function App() {
 		}
 	}
 
+	function onThemeChange(event: ChangeEvent<HTMLSelectElement>) {
+		const nextTheme = event.target.value as GhmdTheme
+		setTheme(nextTheme)
+		capturePostHogEvent('option_changed', {
+			optionName: 'theme',
+			optionValue: nextTheme,
+		})
+	}
+
+	function onModeChange(event: ChangeEvent<HTMLSelectElement>) {
+		const nextMode = event.target.value as GhmdMode
+		setMode(nextMode)
+		capturePostHogEvent('option_changed', {
+			optionName: 'mode',
+			optionValue: nextMode,
+		})
+	}
+
+	function onEmbedCssChange(event: ChangeEvent<HTMLInputElement>) {
+		const nextEmbedCss = event.target.checked
+		setEmbedCss(nextEmbedCss)
+		capturePostHogEvent('option_changed', {
+			optionName: 'embed_css',
+			optionValue: nextEmbedCss,
+		})
+	}
+
 	async function onConvert() {
+		capturePostHogEvent('convert_to_html_clicked', {
+			embedCss,
+			mode,
+			theme,
+			hasMarkdownContent: markdown.trim().length > 0,
+			hasUploadedFile: filename !== 'document.md',
+		})
+
 		try {
 			setBusy(true)
 			setError('')
@@ -92,7 +144,7 @@ export function App() {
 					<select
 						id="theme-select"
 						value={theme}
-						onChange={(event) => setTheme(event.target.value as GhmdTheme)}
+						onChange={onThemeChange}
 					>
 						<option value="system">System</option>
 						<option value="light">Light</option>
@@ -106,7 +158,7 @@ export function App() {
 					<select
 						id="mode-select"
 						value={mode}
-						onChange={(event) => setMode(event.target.value as GhmdMode)}
+						onChange={onModeChange}
 					>
 						<option value="gfm">GitHub Flavored Markdown</option>
 						<option value="markdown">Plain markdown (--no-gfm)</option>
@@ -118,7 +170,7 @@ export function App() {
 					<input
 						type="checkbox"
 						checked={embedCss}
-						onChange={(event) => setEmbedCss(event.target.checked)}
+						onChange={onEmbedCssChange}
 					/>
 					<span>
 						<span className="option-label">Embed CSS</span>


### PR DESCRIPTION
### Motivation
- Track user interactions with the browser Convert and download HTML flow by emitting a custom PostHog event when the conversion action is initiated.

### Description
- Add a global PostHog TypeScript declaration and call `window.posthog?.capture('browser_convert_to_html_clicked', {...})` in `src/browser/src/App.tsx`, sending `embedCss`, `mode`, `theme`, `hasMarkdownContent`, and `hasUploadedFile` properties while guarding the call so it is safe when analytics is not present.

### Testing
- Ran `pnpm --dir src/browser build`, which ran but failed in this environment because Vite could not resolve the local `ghmd-js` package entry (the failure is unrelated to the added capture); no other automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c025aab8e0832bac85633e2312d346)