### PR TITLE
Use shared PostHog capture helper in browser app

### DIFF
--- a/src/browser/src/App.tsx
+++ b/src/browser/src/App.tsx
@@ -46,7 +46,7 @@ export function App() {
 		const [file] = event.target.files ?? []
 		if (!file) return
 
-		window.posthog?.capture('browser_markdown_file_uploaded', {
+		capturePostHogEvent('browser_markdown_file_uploaded', {
 			fileExtension: file.name.split('.').pop()?.toLowerCase(),
 			fileSizeBytes: file.size,
 			fileType: file.type || 'unknown',


### PR DESCRIPTION
### Motivation
- Consolidate PostHog analytics usage in the browser app to use the existing `capturePostHogEvent` helper for consistency and to centralize any future adjustments to event capture.

### Description
- Replace the direct call to `window.posthog?.capture(...)` with `capturePostHogEvent('browser_markdown_file_uploaded', {...})` in `src/browser/src/App.tsx` for the markdown file upload event.

### Testing
- Ran the browser build with `pnpm --dir ./src/browser build`, which failed in this environment because Vite could not resolve the local `ghmd-js` package entry (build failure not caused by the change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c164fbe310832bb5fe29334a6c0938)